### PR TITLE
Fix eating new line in the generated file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ async function processAnnotated (code) {
     var result;
     while((result = reg.exec(code)) !== null) {
         let transformedAnnotation = await transformAnnotation(result[0])
-        transformed = transformed.replace(result[0] + "\n", transformedAnnotation)
+        transformed = transformed.replace(result[0], transformedAnnotation)
         // doSomethingWith(result);
     }
     return transformed


### PR DESCRIPTION
Behavior of the version before this commit:

Passing this code through the elm-coder-generator:
```
-- [generator-start]
-- some types
-- [generator-end]
a: Int
a = 1

would yield:

-- [generator-start]
-- generated codes
-- [generator-end]a: Int
a = 1
```
which is wrong (missing a new line after the end marker)

This commit fixes this problem